### PR TITLE
actions: alte main.pdf umbenennen

### DIFF
--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -65,6 +65,8 @@ jobs:
           if ! docker run --rm -v "$GITHUB_WORKSPACE:/latex" -u $(id -u ${USER}):$(id -g ${USER}) -e DISABLE_DIFFPDF=1 -e DISABLE_SYNCTEX=1 $DOCKER_IMAGE; then
             echo "stop=true" >> $GITHUB_ENV
             echo "::warning::previous build failed, not generating diff"
+          else
+            mv main.pdf main-old.pdf
           fi
       - name: Download new main.pdf
         if: ${{ env.stop != 'true' }}


### PR DESCRIPTION
der diff-job ginbg schief, weil beide dateien main.pdf hiessen. ups

hab's nochmal auf nem dummy-branch getestet, geht jetzt wieder ^^