### PR TITLE
typo im rc-sieb tikz korrigiert

### DIFF
--- a/dinge/rc-sieb.tex
+++ b/dinge/rc-sieb.tex
@@ -20,9 +20,6 @@ to [short, -o] (lower-|A1)
 %down parallels
 (cla) to [capacitor, C=$C_L$, v=$U_{Breff_1}$] (lower-|cla)
 (csa) to [capacitor, C=$C_S$] (lower-|csa)
-(u2a) to [open, v=$U_{Breff_1}$] (lower-|u2a)
-% u3
-%to [open, v=$U_{Breff_2}$] ++(0, -2)
-%to [short, o-*] ++(-2,0)
+(u2a) to [open, v=$U_{Breff_2}$] (lower-|u2a)
 ;
 \end{circuitikz}


### PR DESCRIPTION
* UBreff1 -> UBreff 2
* ungenutzte auskommentierte zeilen entfernen

aufgefallen in #10 ^^