### PR TITLE
Credits und aus Versehen kleineres TOC

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -18,6 +18,9 @@
 Colin Pohle, Eric Richter, Kevin Wenke\\
 nach Original von Marcel Ott.}
 \maketitle
+\vfill
+\scriptsize
+Diese Formelsammlung basiert auf der Light-Version einer \href{https://github.com/DSczyrba/Vorlage-Latex/}{Latex-Vorlage} von \href{https://github.com/jemand771}{Willy Hille}, \href{https://github.com/TheColin21}{Colin Pohle} und \href{https://github.com/DSczyrba}{Dominic Sczyrba}.
 \vfuzz=10pt
 \tableofcontents
 \vfuzz=0.1pt


### PR DESCRIPTION
Ende der Titelseite:
![grafik](https://user-images.githubusercontent.com/24256864/131830545-fb06e879-4bdf-4653-8db3-d7cb7c292f35.png)

Inhaltsverzeichnis auf einer Seite:
![grafik](https://user-images.githubusercontent.com/24256864/131830607-77386da3-b894-4f66-a8e5-d7ae4b919dc0.png)

fixes #17 